### PR TITLE
feat: add chat message interface

### DIFF
--- a/apps/app/globals.css
+++ b/apps/app/globals.css
@@ -27,7 +27,7 @@
     --chart-3: 197 37% 24%;
     --chart-4: 43 74% 66%;
     --chart-5: 27 87% 67%;
-    --radius: 0.5rem
+    --radius: 0.5rem;
   }
   .dark {
     --background: 0 0% 3.9%;
@@ -53,7 +53,7 @@
     --chart-2: 160 60% 45%;
     --chart-3: 30 80% 55%;
     --chart-4: 280 65% 60%;
-    --chart-5: 340 75% 55%
+    --chart-5: 340 75% 55%;
   }
 }
 @layer base {
@@ -62,5 +62,14 @@
   }
   body {
     @apply bg-background text-foreground;
+  }
+}
+
+@layer utilities {
+  [contenteditable="true"]:empty::before {
+    content: attr(data-placeholder);
+    color: gray;
+    display: block;
+    outline: none;
   }
 }

--- a/apps/components/ChatView/ChatBox.tsx
+++ b/apps/components/ChatView/ChatBox.tsx
@@ -2,22 +2,16 @@
 
 import React, { useEffect } from "react";
 import useChatStore from "@/stores/chat";
-import { Button } from "../ui/button";
 import useUserStore from "@/stores/userStore";
-import { Icon } from "@iconify/react";
 import { ModalType, useModalStore } from "@/stores/modalStore";
 import OnboardModal from "../Modals/OnboardModal";
 import AvatarSettingsModal from "../Modals/AvatarSettingsModal";
+import ChatDialog from "./ChatDialog";
 
 const ChatBox = () => {
-  const [counter, setCounter] = React.useState(0);
   const hasUserLogin = useUserStore((state) => state.hasUserLogin);
   const { chatId, hasCreatedTarget, onCreateTarget } = useChatStore();
   const { activeModal, updateActiveModal } = useModalStore();
-
-  const handleSettingsClick = () => {
-    updateActiveModal(ModalType.AVATAR);
-  };
 
   // when creating a new chat, check if user is logged in
   useEffect(() => {
@@ -33,22 +27,7 @@ const ChatBox = () => {
   }, [hasCreatedTarget, hasUserLogin]);
 
   return (
-    <div>
-      {hasCreatedTarget ? (
-        <div className="flex justify-center items-center gap-x-2">
-          <p className="text-center">title:{counter + chatId}</p>
-          <div
-            className="rounded-lg text-xl hover:bg-gray-200 p-2 hover:cursor-pointer"
-            onClick={handleSettingsClick}
-          >
-            <Icon icon="material-symbols:settings-outline" />
-          </div>
-          <Button onClick={() => setCounter(counter + 1)}>+1</Button>
-        </div>
-      ) : (
-        <Button onClick={onCreateTarget}>Create Target</Button>
-      )}
-
+    <>
       <OnboardModal
         isOpen={activeModal === ModalType.USER}
         onClose={() => updateActiveModal(null)}
@@ -57,7 +36,8 @@ const ChatBox = () => {
         isOpen={activeModal === ModalType.AVATAR}
         onClose={() => updateActiveModal(null)}
       />
-    </div>
+      <ChatDialog />
+    </>
   );
 };
 

--- a/apps/components/ChatView/ChatDialog.tsx
+++ b/apps/components/ChatView/ChatDialog.tsx
@@ -1,0 +1,25 @@
+﻿"use client";
+
+import React from "react";
+import ChatMessages from "./ChatMessages";
+import ChatInput from "../form/ChatInput";
+
+const ChatDialog = () => {
+  const [messages, setMessages] = React.useState<string[]>(
+    Array.from({ length: 100 }).map((i) => `\nMessage ${i}`)
+  );
+
+  const addMessages = (message: string) => {
+    console.log("message", message);
+    setMessages((prev) => [...prev, message]);
+  };
+
+  return (
+    <>
+      <ChatMessages messages={messages} />
+      <ChatInput addMessage={addMessages} />
+    </>
+  );
+};
+
+export default ChatDialog;

--- a/apps/components/ChatView/ChatMessages.tsx
+++ b/apps/components/ChatView/ChatMessages.tsx
@@ -1,0 +1,43 @@
+﻿import React from "react";
+import { ScrollArea } from "../ui/scroll-area";
+
+interface ChatMessagesProps {
+  messages: string[];
+}
+
+const ChatMessages = ({ messages }: ChatMessagesProps) => {
+  const scrollRef = React.useRef<HTMLDivElement>(null);
+
+  const scrollToBottom = () => {
+    scrollRef.current?.scrollIntoView(false);
+  };
+
+  React.useEffect(() => {
+    scrollToBottom();
+  }, []);
+
+  React.useEffect(() => {
+    scrollToBottom();
+  }, [messages]);
+
+  return (
+    <ScrollArea className="flex-1 p-5">
+      <div className="flex flex-col gap-y-3" ref={scrollRef}>
+        {messages.map((message, index) => (
+          <p
+            className={`max-w-[80%] flex rounded-lg p-2 text-sm ${
+              index % 2 ? "bg-slate-200" : "self-end bg-blue-200"
+            }`}
+          >
+            Lorem ipsum dolor sit amet consectetur adipisicing elit. Earum
+            dignissimos autem atque numquam praesentium qui? Excepturi deleniti
+            odio quos molestiae soluta reiciendis eaque quam ipsum aut corporis!
+            Asperiores, repudiandae quibusdam. {message}
+          </p>
+        ))}
+      </div>
+    </ScrollArea>
+  );
+};
+
+export default ChatMessages;

--- a/apps/components/ChatView/ChatView.tsx
+++ b/apps/components/ChatView/ChatView.tsx
@@ -10,9 +10,7 @@ const ChatView = () => {
         <h1>{GLOBAL_TITLE}</h1>
         <AvatarButton />
       </div>
-      <div className="flex-1">
-        <ChatBox />
-      </div>
+      <ChatBox />
     </main>
   );
 };

--- a/apps/components/Sidebar/Sidebar.tsx
+++ b/apps/components/Sidebar/Sidebar.tsx
@@ -6,7 +6,7 @@ import ChatCard from "../ChatCard";
 
 const Sidebar = () => {
   return (
-    <main className="p-2 bg-slate-50 w-[260px] h-screen flex flex-col">
+    <main className="p-2 bg-slate-50 w-[260px] h-dvh flex flex-col">
       <div className="px-2 flex flex-row justify-between items-center">
         <div className="rounded-lg text-xl hover:bg-gray-200 p-2 hover:cursor-pointer">
           <Icon icon="akar-icons:panel-left" />

--- a/apps/components/form/ChatInput.tsx
+++ b/apps/components/form/ChatInput.tsx
@@ -1,0 +1,81 @@
+﻿"use client";
+
+import { ModalType, useModalStore } from "@/stores/modalStore";
+import { Icon } from "@iconify/react";
+import React from "react";
+
+interface ChatInputProps {
+  addMessage: (message: string) => void;
+}
+
+const ChatInput = ({ addMessage }: ChatInputProps) => {
+  const inputRef = React.useRef<HTMLDivElement>(null);
+  const updateActiveModal = useModalStore((state) => state.updateActiveModal);
+
+  const resetInput = () => {
+    if (inputRef.current) inputRef.current.innerHTML = "";
+  };
+
+  const getFormatMessage = () => {
+    let message = inputRef.current?.innerText || "";
+    return message
+      .replace(/<div>|<p>/g, "\n")
+      .replace(/<\/div>|<\/p>/g, "")
+      .replace(/<br>/g, "\n");
+  };
+
+  const handleSettingsClick = () => {
+    updateActiveModal(ModalType.AVATAR);
+  };
+
+  const handleEnterPress = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      const message = getFormatMessage();
+      if (message.trim() === "") return;
+      addMessage(message);
+      resetInput();
+    }
+  };
+
+  const handleInputClick = (
+    e: React.MouseEvent<HTMLButtonElement, MouseEvent>
+  ) => {
+    e.preventDefault();
+    const message = getFormatMessage();
+    if (message.trim() === "") return;
+    addMessage(message);
+    resetInput();
+  };
+
+  return (
+    <form className="relative">
+      <button className="absolute start-0 bottom-1.5 flex items-center ps-2">
+        <div
+          className="rounded-lg text-xl p-2 z-50 hover:bg-gray-200  hover:cursor-pointer"
+          onClick={handleSettingsClick}
+        >
+          <Icon icon="material-symbols:settings-outline" />
+        </div>
+      </button>
+      <div
+        className="flex items-center min-h-0 max-h-[100px] rounded-lg border border-input bg-transparent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring py-3 ps-12 pe-12 text-gray-900 overflow-y-auto"
+        contentEditable={true}
+        onKeyDown={handleEnterPress}
+        data-placeholder="Message SynthHead Fusion"
+        ref={inputRef}
+      ></div>
+      <div className="absolute end-1.5 bottom-1.5 flex items-center pe-2">
+        <button
+          type="submit"
+          className="rounded-lg text-xl p-2 z-50 hover:bg-gray-200  hover:cursor-pointer"
+          onClick={handleInputClick}
+        >
+          <Icon icon="icon-park-solid:up-c" />
+        </button>
+      </div>
+    </form>
+  );
+};
+
+export default ChatInput;

--- a/apps/components/ui/textarea.tsx
+++ b/apps/components/ui/textarea.tsx
@@ -1,0 +1,24 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface TextareaProps
+  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+
+const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <textarea
+        className={cn(
+          "flex min-h-[60px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+Textarea.displayName = "Textarea";
+
+export { Textarea };


### PR DESCRIPTION
﻿# Description
- Add interface for chat messages

# Changes
- `apps/app/globals.css`: add placeholder to `contenteditable`
- `apps/components/ChatView/ChatBox.tsx`: change avatar settings modal to input
- `apps/components/ChatView/ChatDialog.tsx`: chat interface
- `apps/components/ChatView/ChatMessages.tsx`: show all chat messages, default scrolls to the bottom(recent messages)
- `apps/components/form/ChatInput.tsx`: input using div `contenteditable` and will send the input to `ChatMessages.tsx`

# Screenshots
<img width="1240" alt="image" src="https://github.com/user-attachments/assets/a7fc2433-9b0f-4cdb-8f1f-ae4db3e48a85">


*Notes: all messages are fake, haven't link to the backend*